### PR TITLE
Fix copyright symbol formatting in ucetd.cls to be in accordance with library guidelines

### DIFF
--- a/ucetd.cls
+++ b/ucetd.cls
@@ -21,7 +21,7 @@
 % Default copyright text
 \newcommand{\etdCopyrightText}{
 	\null\vfill
-	\centerline{Copyright \textcopyright\ \number\year\ by \@author}
+	\centerline{\textcopyright\ \number\year\ by \@author}
 	\centerline{All Rights Reserved}
 	\vskip 15pt\relax
 }


### PR DESCRIPTION
Library asked to have either "Copyright" XOR "(C)"